### PR TITLE
Add options for exiting fullscreen using the mouse

### DIFF
--- a/zotero-focused-mode/locale/en-US/toggles.ftl
+++ b/zotero-focused-mode/locale/en-US/toggles.ftl
@@ -2,3 +2,5 @@ toggle-combined =
     .label = Toggle Interface Elements
 toggle-focused-combined =
     .label = Focused Reading Mode
+toggle-focused-right-click =
+    .label = Exit Focused Reading


### PR DESCRIPTION
Closes #1 

This PR adds two ways of leaving fullscreen without the mouse. With the first, you can access the 'View' menu by mousing over the top of the screen, and exit by clicking on `Focused Reading Mode`.

The second is a menu item I added the the right-click menu when fullscreen is active. This is the only way to exit on MacOS, because the titlebar containing the 'View' menu is not a part of the Zotero window on Mac, and I don't know how to call it up. This right-click menu item could be something that only shows up on Mac, if you want.

Let me know if this looks good. I'm also interested in adding a preference toggle for keeping the annotation bar visible during fullscreen but that's a separate issue.